### PR TITLE
Add init_queries settings

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -101,8 +101,10 @@ class Dodo(QApplication):
             timer.timeout.connect(self.sync_mail)
             timer.start(settings.sync_mail_interval * 1000)
 
-        # open inbox and make un-closeable
-        self.open_search('tag:inbox', keep_open=True)
+        # open init_queries and make un-closeable
+        #
+        for query in settings.init_queries:
+            self.open_search(query, keep_open=True)
 
     def show_help(self) -> None:
         """Show help window"""

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -135,6 +135,13 @@ automatically when a panel (or Dodo) is closed. Possible values are: 'always', '
 or 'ask'.
 """
 
+init_queries = [ 'tag:inbox' ]
+"""List of non closable queries open at startup
+
+You can save query with `notmuch config set query:inbox "tag:inbox and not
+tag:trash"` and use `query:inbox` as a search term.
+"""
+
 # security
 html_block_remote_requests = True
 """Block remote requests for HTML messages


### PR DESCRIPTION
Similar to what is done in astroid. 
It allows to have several panels open at startup with often used queries.