### PR TITLE
Use QWebEngineUrlRequestInterceptor to block remote requests

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -169,6 +169,11 @@ class EmbeddedImageHandler(QWebEngineUrlSchemeHandler):
         if not content_type:
             request.fail(QWebEngineUrlRequestJob.Error.UrlNotFound)
 
+class RemoteBlockingUrlRequestInterceptor(QWebEngineUrlRequestInterceptor):
+    def interceptRequest(self, info):
+        if info.requestUrl().scheme() not in app.LOCAL_PROTOCOLS:
+            info.block(settings.html_block_remote_requests)
+
 class ThreadModel(QAbstractItemModel):
     """A model containing a thread, its messages, and some metadata
 
@@ -307,6 +312,10 @@ class ThreadPanel(panel.Panel):
         self.message_profile.installUrlSchemeHandler(b'message', self.message_handler)
         self.message_profile.settings().setAttribute(
                 QWebEngineSettings.WebAttribute.JavascriptEnabled, False)
+
+        # The interceptor must not be garbage collected, so keep a reference
+        self.url_interceptor = RemoteBlockingUrlRequestInterceptor()
+        self.message_profile.setUrlRequestInterceptor(self.url_interceptor)
 
         self.message_view = QWebEngineView(self)
         page = MessagePage(self.app, self.message_profile, self.message_view)


### PR DESCRIPTION
`QWebEnginePage.acceptNavigationRequest` only intercepts navigating to a different URL (i.e. clicking a link). Any other requests don't use this method, so remote images, stylesheets, etc. will still be loaded.

This can easily be seen by opening any HTML message that contains a remote image - it is displayed regardless of `settings.html_block_remote_requests`. Obviously this can enable tracking in malicious messages.

This can be fixed by also setting a `QWebEngineUrlRequestInterceptor` on the profile. That way, all requests are intercepted and can be allowed or denied depending on `settings.html_block_remote_requests`.