### PR TITLE
Allow for tags with whitespaces and special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ def snooze(days, mode='tag'):
     import datetime
     d = datetime.date.today() + datetime.timedelta(days=days)
     def f(search):
-        search.tag_thread(f'-inbox -unread +zzz-{d}', mode)
+        search.tag_thread(tags_remove=['inbox', 'unread'], tags_add=[f'zzz-{d}'], mode=mode)
     return f
 
 dodo.keymap.search_keymap['z z'] = ("snooze for 1 day", snooze(days=1))

--- a/dodo/app.py
+++ b/dodo/app.py
@@ -230,8 +230,8 @@ class Dodo(QApplication):
         def callback(tag_expr: str) -> None:
             w = self.tabs.currentWidget()
             if w and isinstance(w, panel.Panel):
-                if isinstance(w, search.SearchPanel): w.tag_thread(tag_expr, mode)
-                elif isinstance(w, thread.ThreadPanel): w.tag_message(tag_expr)
+                if isinstance(w, search.SearchPanel): w.tag_thread(tag_expr=tag_expr, mode=mode)
+                elif isinstance(w, thread.ThreadPanel): w.tag_message(tag_expr=tag_expr)
                 w.refresh()
         self.command_bar.open(mode, callback)
 

--- a/dodo/keymap.py
+++ b/dodo/keymap.py
@@ -52,7 +52,7 @@ search_keymap = {
   'C-d':     ('down 20', lambda p: [p.next_thread() for i in range(20)]),
   'C-u':     ('up 20', lambda p: [p.previous_thread() for i in range(20)]),
   '<enter>': ('open thread', lambda p: p.open_current_thread()),
-  'a':       ('tag -inbox -unread', lambda p: p.tag_thread('-inbox -unread')),
+  'a':       ('tag -inbox -unread', lambda p: p.tag_thread(tags_remove=['inbox', 'unread'])),
   'u':       ('toggle unread', lambda p: p.toggle_thread_tag('unread')),
   'f':       ('toggle flagged', lambda p: p.toggle_thread_tag('flagged')),
   '<space>': ('toggle marked', lambda p: [p.toggle_thread_tag('marked'), p.next_thread()]),

--- a/dodo/tag.py
+++ b/dodo/tag.py
@@ -50,10 +50,10 @@ class TagModel(QAbstractItemModel):
         self.d: List[Tuple[str,str,str]] = []
 
         for t in tag_str.splitlines():
-            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', 'tag:'+t],
+            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:"{t}"'],
                     stdout=subprocess.PIPE)
             c = r1.stdout.decode('utf-8').strip()
-            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:{t} AND tag:unread'],
+            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:"{t}" AND tag:unread'],
                     stdout=subprocess.PIPE)
             cu = r1.stdout.decode('utf-8').strip()
             self.d.append((t, cu, c))
@@ -208,7 +208,7 @@ class TagPanel(panel.Panel):
 
         tag = self.model.tag(self.tree.currentIndex())
         if tag:
-            self.app.open_search('tag:' + tag)
+            self.app.open_search(f'tag:"{tag}"')
     
 
 

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -31,6 +31,7 @@ import html
 import email
 import email.message
 import tempfile
+import shlex
 
 from . import app
 from . import settings
@@ -420,7 +421,7 @@ class ThreadPanel(panel.Panel):
             m = self.model.message_at(self.current_message)
             if 'unread' in m['tags']:
                 # this might change the filename, so we should refresh the model
-                self.tag_message('-unread')
+                self.tag_message(tags_remove=['unread'])
                 self.refresh()
                 m = self.model.message_at(self.current_message)
 
@@ -476,22 +477,24 @@ class ThreadPanel(panel.Panel):
         m = self.model.message_at(self.current_message)
         if m:
             if tag in m['tags']:
-                tag_expr = '-' + tag
+                self.tag_message(tags_remove=[tag])
             else:
-                tag_expr = '+' + tag
-            self.tag_message(tag_expr)
+                self.tag_message(tags_add=[tag])
 
-    def tag_message(self, tag_expr: str) -> None:
-        """Apply the given tag expression to the current message
+    def tag_message(self, tag_expr: str=None, tags_add: list=None, tags_remove: list=None) -> None:
+        """Apply the given tag expression or lists of tags to add or remove to the selected thread
 
         A tag expression is a string consisting of one more statements of the form "+TAG"
-        or "-TAG" to add or remove TAG, respectively, separated by whitespace."""
+        or "-TAG" to add or remove TAG, respectively, separated by whitespace.
+        
+        Tags containing spaces or special characters must be double quoted within the tag expression.
+        Alternatively, use the lists tags_add and tags_remove with the unquoted values.
+        Programatic uses of tags should always use the tags_add and tags_remove lists."""
 
         m = self.model.message_at(self.current_message)
         if m:
-            if not ('+' in tag_expr or '-' in tag_expr):
-                tag_expr = '+' + tag_expr
-            r = subprocess.run(['notmuch', 'tag'] + tag_expr.split() + ['--', 'id:' + m['id']],
+            tag_args = util.format_tag_args(tag_expr, tags_add, tags_remove)
+            r = subprocess.run(['notmuch', 'tag'] + tag_args + ['--', 'id:' + m['id']],
                     stdout=subprocess.PIPE)
             self.app.refresh_panels()
 

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -515,3 +515,24 @@ def key_string(e: QKeyEvent) -> str:
 
     # print(cmd)
     return cmd
+
+def format_tag_args(tag_expr: str=None, tags_add: list=None, tags_remove: list=None) -> list:
+    tag_args = []
+    if tag_expr:
+        # This is something typed by the user in the search or thread panel
+        # assume that they use whitepace and quotes correctly
+        for tag in shlex.split(tag_expr):
+            if tag[0] not in ['+', '-']:
+                tag = '+' + tag
+            if ' ' in tag:
+                # For example: shlex.split('+asdf +"asdf asdf"') => ['+asdf', '+asdf asdf']
+                # shelx.split removed quotes, so add them back
+                tag = tag[0] + f'"{tag[1:]}"'
+            tag_args.append(tag)
+    if tags_add:
+        for tag in tags_add:
+            tag_args.append(f'+"{tag}"')
+    if tags_remove:
+        for tag in tags_remove:
+            tag_args.append(f'-"{tag}"')
+    return tag_args


### PR DESCRIPTION
Here's an attempt to solve https://github.com/akissinger/dodo/issues/29

I've tested
- [x] see correct [read/unread] counts for `tags like/this` in the tag panel
- [x] double clicking a tag in the tag panel correctly gives the search results for that tag
- [x] the tag in the search query itself is excluded from the shows tags

Not tested:
- adding/removing tags
- command bar
- probably some other things I'm unfamiliar with since I haven't fully explored all the features in dodo yet. I'm mainly using as a read-only interface for now as I get used to things.