### PR TITLE
Tagfixing tagnarrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ def snooze(days, mode='tag'):
     import datetime
     d = datetime.date.today() + datetime.timedelta(days=days)
     def f(search):
-        search.tag_thread(f'-inbox -unread +zzz-{d}', mode)
+        search.tag_thread(tags_remove=['inbox', 'unread'], tags_add=[f'zzz-{d}'], mode=mode)
     return f
 
 dodo.keymap.search_keymap['z z'] = ("snooze for 1 day", snooze(days=1))

--- a/dodo/app.py
+++ b/dodo/app.py
@@ -220,6 +220,10 @@ class Dodo(QApplication):
 
         p = tag.TagPanel(self, keep_open)
         self.add_panel(p)
+    
+    def open_tags_narrowed(self, filter_tags) -> None:
+        p = tag.TagPanel(self, filter_tags=filter_tags)
+        self.add_panel(p)
 
     def search_bar(self) -> None:
         """Open command bar for searching"""
@@ -278,6 +282,13 @@ class Dodo(QApplication):
 
         w = self.tabs.currentWidget()
         if w and isinstance(w, panel.Panel): w.refresh()
+
+    def refresh_title(self) -> None:
+        """Refresh the title of the current panel"""
+        i = self.tabs.currentIndex()
+        w = self.tabs.widget(i)
+        if isinstance(w, panel.Panel):
+            self.tabs.setTabText(i, w.title())
 
     def prompt_quit(self) -> None:
         """A 'soft' quit function, which gives each open tab the opportunity to prompt

--- a/dodo/app.py
+++ b/dodo/app.py
@@ -230,8 +230,8 @@ class Dodo(QApplication):
         def callback(tag_expr: str) -> None:
             w = self.tabs.currentWidget()
             if w and isinstance(w, panel.Panel):
-                if isinstance(w, search.SearchPanel): w.tag_thread(tag_expr, mode)
-                elif isinstance(w, thread.ThreadPanel): w.tag_message(tag_expr)
+                if isinstance(w, search.SearchPanel): w.tag_thread(tag_expr=tag_expr, mode=mode)
+                elif isinstance(w, thread.ThreadPanel): w.tag_message(tag_expr=tag_expr)
                 w.refresh()
         self.command_bar.open(mode, callback)
 

--- a/dodo/helpwindow.py
+++ b/dodo/helpwindow.py
@@ -41,6 +41,7 @@ class HelpWindow(QWidget):
         maps = [
             ("Global", keymap.global_keymap),
             ("Search view", keymap.search_keymap),
+            ("Tag view", keymap.tag_keymap),
             ("Thread view", keymap.thread_keymap),
             ("Compose view", keymap.compose_keymap),
             ("Command bar", keymap.command_bar_keymap),

--- a/dodo/keymap.py
+++ b/dodo/keymap.py
@@ -52,7 +52,7 @@ search_keymap = {
   'C-d':     ('down 20', lambda p: [p.next_thread() for i in range(20)]),
   'C-u':     ('up 20', lambda p: [p.previous_thread() for i in range(20)]),
   '<enter>': ('open thread', lambda p: p.open_current_thread()),
-  'a':       ('tag -inbox -unread', lambda p: p.tag_thread('-inbox -unread')),
+  'a':       ('tag -inbox -unread', lambda p: p.tag_thread(tags_remove=['inbox', 'unread'])),
   'u':       ('toggle unread', lambda p: p.toggle_thread_tag('unread')),
   'f':       ('toggle flagged', lambda p: p.toggle_thread_tag('flagged')),
   '<space>': ('toggle marked', lambda p: [p.toggle_thread_tag('marked'), p.next_thread()]),

--- a/dodo/keymap.py
+++ b/dodo/keymap.py
@@ -72,7 +72,11 @@ tag_keymap = {
   'G':       ('last tag', lambda p: p.last_tag()),
   'C-d':     ('down 20', lambda p: [p.next_tag() for i in range(20)]),
   'C-u':     ('up 20', lambda p: [p.previous_tag() for i in range(20)]),
-  '<enter>': ('search tag', lambda p: p.search_current_tag()),
+  '<enter>': ('search with selected tag', lambda p: p.search_current_tag()),
+  '<space>': ('search without selected tag', lambda p: p.search_current_view()),
+  'N':       ('narrow to tag in new panel', lambda p: p.open_current_tag()),
+  'n':       ('narrow to tag', lambda p: p.narrow_current_tag()),
+  'b':       ('undo last narrow to tag', lambda p: p.undo_narrow_tag()),
 }
 """The local keymap for the tag panel
 

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import QTreeView, QWidget
 from PyQt6.QtGui import QFont, QColor
 import subprocess
 import json
+import shlex
 
 from . import app
 from . import settings
@@ -95,7 +96,13 @@ class SearchModel(QAbstractItemModel):
                 tag_icons = []
                 for t in thread_d['tags']:
                     # don't bother showing TAG if it is in settings.hide_tags or the query is specifically 'tag:TAG'
-                    if t not in settings.hide_tags and self.q != f'tag:"{t}"':
+                    tag_in_q = False
+                    for q_part in shlex.split(self.q):
+                        # Example: shlex.split('asdf tag:blah AND tag:"blah blah"') => ['asdf', 'tag:blah', 'AND', 'tag:blah blah']
+                        if q_part.startswith('tag:') and t == q_part.lstrip('tag:'):
+                            tag_in_q = True
+                            break
+                    if t not in settings.hide_tags and not tag_in_q:
                         tag_icons.append(settings.tag_icons[t] if t in settings.tag_icons else f'[{t}]')
                 return ' '.join(tag_icons)
         elif role == Qt.ItemDataRole.FontRole:

--- a/dodo/tag.py
+++ b/dodo/tag.py
@@ -50,10 +50,10 @@ class TagModel(QAbstractItemModel):
         self.d: List[Tuple[str,str,str]] = []
 
         for t in tag_str.splitlines():
-            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', 'tag:'+t],
+            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:"{t}"'],
                     stdout=subprocess.PIPE)
             c = r1.stdout.decode('utf-8').strip()
-            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:{t} AND tag:unread'],
+            r1 = subprocess.run(['notmuch', 'count', '--output=threads', '--', f'tag:"{t}" AND tag:unread'],
                     stdout=subprocess.PIPE)
             cu = r1.stdout.decode('utf-8').strip()
             self.d.append((t, cu, c))
@@ -208,7 +208,7 @@ class TagPanel(panel.Panel):
 
         tag = self.model.tag(self.tree.currentIndex())
         if tag:
-            self.app.open_search('tag:' + tag)
+            self.app.open_search(f'tag:"{tag}"')
     
 
 

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -31,7 +31,6 @@ import html
 import email
 import email.message
 import tempfile
-import shlex
 
 from . import app
 from . import settings

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -31,6 +31,7 @@ import html
 import email
 import email.message
 import tempfile
+import shlex
 
 from . import app
 from . import settings
@@ -420,7 +421,7 @@ class ThreadPanel(panel.Panel):
             m = self.model.message_at(self.current_message)
             if 'unread' in m['tags']:
                 # this might change the filename, so we should refresh the model
-                self.tag_message('-unread')
+                self.tag_message(tags_remove=['unread'])
                 self.refresh()
                 m = self.model.message_at(self.current_message)
 
@@ -476,22 +477,24 @@ class ThreadPanel(panel.Panel):
         m = self.model.message_at(self.current_message)
         if m:
             if tag in m['tags']:
-                tag_expr = '-' + tag
+                self.tag_message(tags_remove=[tag])
             else:
-                tag_expr = '+' + tag
-            self.tag_message(tag_expr)
+                self.tag_message(tags_add=[tag])
 
-    def tag_message(self, tag_expr: str) -> None:
-        """Apply the given tag expression to the current message
+    def tag_message(self, tag_expr: str=None, tags_add: list=None, tags_remove: list=None) -> None:
+        """Apply the given tag expression or lists of tags to add or remove to the selected thread
 
         A tag expression is a string consisting of one more statements of the form "+TAG"
-        or "-TAG" to add or remove TAG, respectively, separated by whitespace."""
+        or "-TAG" to add or remove TAG, respectively, separated by whitespace.
+        
+        Tags containing spaces or special characters must be double quoted within the tag expression.
+        Alternatively, use the lists tags_add and tags_remove with the unquoted values.
+        Programatic uses of tags should always use the tags_add and tags_remove lists."""
 
         m = self.model.message_at(self.current_message)
         if m:
-            if not ('+' in tag_expr or '-' in tag_expr):
-                tag_expr = '+' + tag_expr
-            r = subprocess.run(['notmuch', 'tag'] + tag_expr.split() + ['--', 'id:' + m['id']],
+            tag_args = util.format_tag_args(tag_expr, tags_add, tags_remove)
+            r = subprocess.run(['notmuch', 'tag'] + tag_args + ['--', 'id:' + m['id']],
                     stdout=subprocess.PIPE)
             self.app.refresh_panels()
 

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -30,6 +30,7 @@ import email.header
 import textwrap
 from bleach.sanitizer import Cleaner
 from bleach.linkifier import Linker
+import shlex
 
 from . import settings
 

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -515,3 +515,24 @@ def key_string(e: QKeyEvent) -> str:
 
     # print(cmd)
     return cmd
+
+def format_tag_args(tag_expr: str=None, tags_add: list=None, tags_remove: list=None) -> list:
+    tag_args = []
+    if tag_expr:
+        # This is something typed by the user in the search or thread panel
+        # assume that they use whitepace and quotes correctly
+        for tag in shlex.split(tag_expr):
+            if tag[0] not in ['+', '-']:
+                tag = '+' + tag
+            if ' ' in tag:
+                # For example: shlex.split('+asdf +"asdf asdf"') => ['+asdf', '+asdf asdf']
+                # shelx.split removed quotes, so add them back
+                tag = tag[0] + f'"{tag[1:]}"'
+            tag_args.append(tag)
+    if tags_add:
+        for tag in tags_add:
+            tag_args.append(f'+"{tag}"')
+    if tags_remove:
+        for tag in tags_remove:
+            tag_args.append(f'-"{tag}"')
+    return tag_args


### PR DESCRIPTION
Building off https://github.com/akissinger/dodo/pull/30 to work with complex tags, I added the ability to filter the tag view with increasing narrowing. 

- allow narrowing to tags
    - N = new panel with narrowing to the current selected tag
    - n = refresh current panel (and update title) with narrowing to the selected tag, or open search if can't be narrowed further
    - b = undo last narrowing in current panel
    - space = open search view without including current selected row
- show tag view info in help panel
- in search view don't show tags that are in queries with multiple tags
