### PR TITLE
enable display of messages with tag in in search.exclude_tags

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -188,7 +188,7 @@ class ThreadModel(QAbstractItemModel):
     def refresh(self) -> None:
         """Refresh the model by calling "notmuch show"."""
 
-        r = subprocess.run(['notmuch', 'show', '--format=json', '--verify', '--include-html', self.thread_id],
+        r = subprocess.run(['notmuch', 'show', '--exclude=false', '--format=json', '--verify', '--include-html', self.thread_id],
                 stdout=subprocess.PIPE, encoding='utf8')
         self.json_str = r.stdout
         self.d = json.loads(self.json_str)


### PR DESCRIPTION
Messages with such tags, for example 'trash', appear in search results when the tag is explicitly mentioned and must be displayable in the panel.

fixes #35 