### PR TITLE
feature: compose: allow not storing the sent emails

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -468,14 +468,17 @@ class SendmailThread(QThread):
             sendmail.wait(30)
             if sendmail.returncode == 0:
                 # save to sent folder
-                m = mailbox.MaildirMessage(str(eml))
-                m.set_flags('S')
                 if isinstance(settings.sent_dir, dict):
                     sent_dir = settings.sent_dir[account]
                 else:
                     sent_dir = settings.sent_dir
-                key = mailbox.Maildir(sent_dir).add(m)
-                # print(f'add: {key}')
+                # None means we should discard the email, presumably because it's already
+                # handled by whatever mechanism sends it in the first place
+                if sent_dir is not None:
+                    m = mailbox.MaildirMessage(str(eml))
+                    m.set_flags('S')
+                    key = mailbox.Maildir(sent_dir).add(m)
+                    # print(f'add: {key}')
 
                 subprocess.run(['notmuch', 'new', '--no-hooks'])
 

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -53,6 +53,10 @@ This will usually be a subdirectory of the Maildir sync'ed with
 :func:`~dodo.settings.sync_mail_command`. This setting can be given either
 as a string to use one global sent directory, or as a dictionary mapping
 account names in :func:`~dodo.settings.smtp_accounts` to their own sent dirs.
+
+A value of None, either standalone or as one of the dict value, can be used to
+indicate the email should be discarded. This can be useful if the sendmail
+command already has a mechanism for that feature.
 """
 
 editor_command = "xterm -e vim '{file}'"


### PR DESCRIPTION
I'm using lieer/gmi to send email, and it has the builtin assumption
that no new messages will be added to the maildir.

See https://github.com/gauteh/lieer/issues/54