### PR TITLE
thread: explicitly reset the scroll in show_message()

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -413,7 +413,10 @@ class ThreadPanel(panel.Panel):
         If an index is provided, switch the current message to that index, otherwise refresh
         the view of the current message.
         """
-        if i != -1: self.current_message = i
+        if i == self.current_message:
+            return
+        elif i != -1:
+            self.current_message = i
 
         if self.current_message >= 0 and self.current_message < self.model.num_messages():
             self.refresh()
@@ -432,6 +435,7 @@ class ThreadPanel(panel.Panel):
                 self.message_view.page().setUrl(QUrl('message:html'))
             else:
                 self.message_view.page().setUrl(QUrl('message:plain'))
+            self.scroll_message(pos = 'top')
 
 
     def next_message(self) -> None:


### PR DESCRIPTION
At least on my system, the panel keeps its original scroll position when changing the contents of the mail view, which makes for a rather poor experience, especially on smaller screens. Since the docstring of refresh() implies that this is the intended behaviour of show_message (at least when given -1 as index), this should be alright.

In addition to the scroll reset, this patch adds a guard at the top to do an early bail if we're asking to display the same message. That's to avoid the redisplay and scroll reset when trying to jump past the last message of the thread, which is something I often do.