### PR TITLE
add configuration option for running notmuch hooks on send

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -482,7 +482,10 @@ class SendmailThread(QThread):
                     key = mailbox.Maildir(sent_dir).add(m)
                     # print(f'add: {key}')
 
-                subprocess.run(['notmuch', 'new', '--no-hooks'])
+                notmuch_command = [ 'notmuch', 'new' ]
+                if settings.no_hooks_on_send:
+                    notmuch_command.append( '--no-hooks' )
+                subprocess.run(notmuch_command)
 
                 if ((self.panel.mode == 'reply' or self.panel.mode == 'replyall') and
                         self.panel.msg and 'id' in self.panel.msg):

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -161,6 +161,14 @@ You can save query with `notmuch config set query:inbox "tag:inbox and not
 tag:trash"` and use `query:inbox` as a search term.
 """
 
+no_hooks_on_send = True
+"""disable/enable calling notmuch hooks when sending email
+
+When True, 'notmuch new' is called with --no-hooks when a message is sent. One
+may not wanting to wait for the hooks on each sent email, for example when
+calling mbsync on their notmuch hooks. Other users may set this to False, for
+example when notmuch hooks are used to archive sent mail."""
+
 # security
 html_block_remote_requests = True
 """Block remote requests for HTML messages


### PR DESCRIPTION
commit [9205010114ecc5d243c3a3fe72f2bed5b1c3a879](https://github.com/akissinger/dodo/commit/9205010114ecc5d243c3a3fe72f2bed5b1c3a879) changed the behavior of dodo when sending mails: notmuch hooks were no longer called for efficiency reasons. However, some users may want the notmuch hooks to be called when sending mail, for example when they are used to archive sent mail. This PR makes running notmuch hooks on send configurable. The default is to not run the hooks, so this commit does not alter the current behavior.