### PR TITLE
Html charset

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -465,7 +465,7 @@ class SendmailThread(QThread):
             cmd = settings.send_mail_command.replace('{account}', account)
             sendmail = Popen(cmd, stdin=PIPE, encoding='utf8', shell=True)
             if sendmail.stdin:
-                sendmail.stdin.write(str(eml))
+                sendmail.stdin.write(eml.as_string())
                 sendmail.stdin.close()
             sendmail.wait(30)
             if sendmail.returncode == 0:

--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -409,7 +409,7 @@ class SendmailThread(QThread):
         try:
             account = self.panel.account_name()
             m = email.message_from_string(self.panel.message_string)
-            eml = email.message.EmailMessage(policy=email.policy.EmailPolicy(utf8=True))
+            eml = email.message.EmailMessage(policy=email.policy.EmailPolicy(utf8=False))
             attachments: List[str] = m.get_all('A', [])
 
             # n.b. this kills duplicate headers. May want to revisit this if it causes problems.

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -29,7 +29,7 @@ import sys
 import traceback
 import subprocess
 import json
-import html
+import re
 import email
 import email.message
 import tempfile
@@ -114,6 +114,8 @@ class MessageHandler(QWebEngineUrlSchemeHandler):
             buf.open(QIODevice.OpenModeFlag.WriteOnly)
             if mode == 'html':
                 html = util.body_html(self.message_json)
+                html = re.sub(r'(<meta(?!\s*(?:name|value)\s*=)[^>]*?charset\s*=[\s"\']*)([^\s"\'/>]*)',
+                              r'\1utf-8', html, flags=re.M)
                 if html: buf.write(html.encode('utf-8'))
             else:
                 for filt in settings.message2html_filters:


### PR DESCRIPTION
fix: notmuch-show ensures the html body is always in utf-8, modify html header to reflect this. This fixes HTML view of emails encoded in charset other than utf-8, (e.g. CJK).