### PR TITLE
fix TreeView column width bug

### DIFF
--- a/dodo/search.py
+++ b/dodo/search.py
@@ -191,6 +191,9 @@ class SearchPanel(panel.Panel):
 
         super().refresh()
 
+        self.tree.setColumnWidth(1, 150)
+        self.tree.setColumnWidth(2, 900)
+
     def title(self) -> str:
         """Give the query as the tab title"""
 


### PR DESCRIPTION
After refreshing the model, QT resets the column width to fit the content. We do not want this behaviour.

Problem:
![image](https://github.com/akissinger/dodo/assets/57678928/5b501bcd-0666-415f-9d30-8fe7e9c0ad5d)

After fix:
![image](https://github.com/akissinger/dodo/assets/57678928/4e9f9db4-6081-4242-be0e-e71ab27ec20f)
