### PR TITLE
Do a case-insensitive content-type comparison

### DIFF
--- a/dodo/util.py
+++ b/dodo/util.py
@@ -177,7 +177,7 @@ def find_content(m: dict, content_type: str) -> List[str]:
     part with the given content-type."""
 
     return [part['content'] for part in message_parts(m)
-              if 'content' in part and part.get('content-type') == content_type]
+              if 'content' in part and part.get('content-type', '').casefold() == content_type.casefold()]
 
 def body_text(m: dict) -> str:
     """Get the body text of a message


### PR DESCRIPTION
I have email in my inbox that use TEXT/PLAIN as a content-type, and according to https://www.w3.org/Protocols/rfc1341/4_Content-Type.html that's valid:

> The type, subtype, and parameter names are not case sensitive.
> For example, TEXT, Text, and TeXt are all equivalent