### PR TITLE
colorize_text: use raw strings for regex

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -74,7 +74,7 @@ class ComposePanel(panel.Panel):
         if msg:
             senders: List[str] = []
             recipients: List[str] = []
-            email_sep = re.compile('\s*,\s*')
+            email_sep = re.compile(r'\s*,\s*')
             if 'From' in msg['headers']:
                 senders.append(msg["headers"]["From"])
             if 'To' in msg['headers']:

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -114,8 +114,8 @@ def colorize_text(s: str, has_headers: bool=False) -> str:
     """
 
     s1 = ""
-    quoted = re.compile('^\s*&gt;')
-    empty = re.compile('^\s*$')
+    quoted = re.compile(r'^\s*&gt;')
+    empty = re.compile(r'^\s*$')
 
     headers = has_headers
     for ln in s.splitlines():


### PR DESCRIPTION
This silences the following warnings in Python 3.12:

dodo/util.py:118: SyntaxWarning: invalid escape sequence '\s'
  quoted = re.compile('^\s*&gt;')
dodo/util.py:119: SyntaxWarning: invalid escape sequence '\s'
  empty = re.compile('^\s*$')

The actual behaviour doesn't change, as Python inserts the \ when the escape sequence is invalid (checked on Python 3.12)