### PR TITLE
compose: directly load the draft into the final EmailMessage object

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -27,10 +27,12 @@ import email
 import email.utils
 import email.parser
 import email.policy
+import email.message
 import mimetypes
 import subprocess
 from subprocess import PIPE, Popen, TimeoutExpired
 import tempfile
+import typing
 import os
 import re
 
@@ -411,19 +413,14 @@ class SendmailThread(QThread):
     def run(self) -> None:
         try:
             account = self.panel.account_name()
-            m = email.message_from_string(self.panel.message_string)
-            eml = email.message.EmailMessage(policy=email.policy.EmailPolicy(utf8=False))
-            attachments: List[str] = m.get_all('A', [])
-
-            # n.b. this kills duplicate headers. May want to revisit this if it causes problems.
-            for h in m.keys():
-                if h != 'A':
-                    eml[h] = m[h]
+            eml = typing.cast(email.message.EmailMessage, email.message_from_string(
+                self.panel.message_string,
+                policy = email.policy.EmailPolicy(utf8=False)))
+            attachments: List[str] = eml.get_all('A', [])
+            del eml['A']
 
             eml['Message-ID'] = email.utils.make_msgid()
             eml['User-Agent'] = 'Dodo'
-
-            eml.set_content(m.get_payload())
 
             # add a date if it's missing
             if not "Date" in eml:


### PR DESCRIPTION
This simplifies the code as we don't have to copy the data over from the temporary Message object. The header copying in particular was failing when using multiline headers as allowed by RFC 822.

I'm guessing we *could* get into trouble with encoding though? Since I'm using UTF-8 everywhere it works fine for me.