### PR TITLE
add newline to A: pseudo header when adding attachment

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -237,7 +237,7 @@ class ComposePanel(panel.Panel):
         if settings.file_picker_command == None:
             f = QFileDialog.getOpenFileName()
             if f[0]:
-                self.raw_message_string = util.add_header_line(self.raw_message_string, 'A: ' + f[0])
+                self.raw_message_string = util.add_header_line(self.raw_message_string, f'A: {f[0]}\n')
                 self.refresh()
         else:
             fd, file = tempfile.mkstemp()
@@ -250,7 +250,7 @@ class ComposePanel(panel.Panel):
 
             for att in file_list:
                 if att != '':
-                    self.raw_message_string = util.add_header_line(self.raw_message_string, 'A: ' + att)
+                    self.raw_message_string = util.add_header_line(self.raw_message_string, f'A: {att}\n')
             self.refresh()
 
 


### PR DESCRIPTION
The eutil.add_header_line function, used to add the pseudo header, expects a newline terminated string. Otherwise it will remove the RFC defined newline between header and body in the message being composed.

fixes #49 