### PR TITLE
unfold filename from content-disposition header

### DIFF
--- a/dodo/util.py
+++ b/dodo/util.py
@@ -28,6 +28,7 @@ import subprocess
 import email
 import email.header
 import email.utils
+import email.policy
 import textwrap
 from bleach.sanitizer import Cleaner
 from bleach.linkifier import Linker
@@ -240,12 +241,12 @@ def write_attachments(m: dict) -> Tuple[str, List[str]]:
 
     for filename in m['filename']:
         with open(filename, 'r') as f:
-            msg = email.message_from_file(f)
+            msg = email.message_from_file(f,policy=email.policy.default)
             for part in msg.walk():
                 if part.get_content_disposition() == 'attachment':
                     p = temp_dir + '/' + decode_header(part.get_filename())
                     with open(p, 'wb') as att:
-                        att.write(part.get_payload(decode=True))
+                        att.write(part.get_content())
                     file_paths.append(p)
 
     if len(file_paths) == 0:


### PR DESCRIPTION
When line wrapping in a folded content-disposition header occurs within its filename parameter value, then the get_filename() method of the (legacy) email.message.Message object returns a string containing a newline character at the position where the filename parameter value wraps. An attachment filename containing a newline character may result in undefined behaviour with file management tools or scripts and may have security implication. It also prevents forwarding mail in dodo by throwing the exception 'Header values may not contain linefeed or carriage return characters', because the filename is copied in the A: pseudo-header.

This bug is not present in the email.message.EmailMessage class, which is used when specifying the policy email.policy.default.

Additionally, the legacy method get_payload() is replaced by get_content().

Solves #52 