### PR TITLE
Allow for thread-level refreshes

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -282,6 +282,15 @@ class Dodo(QApplication):
         w = self.tabs.currentWidget()
         if w and isinstance(w, panel.Panel): w.refresh()
 
+    def update_single_thread(self, thread_id: str):
+        current = self.tabs.currentWidget()
+        for i in range(self.num_panels()):
+            w = self.tabs.widget(i)
+            if isinstance(w, panel.Panel):
+                w.update_thread(thread_id)
+                if w == current and w.dirty:
+                    w.refresh()
+
     def prompt_quit(self) -> None:
         """A 'soft' quit function, which gives each open tab the opportunity to prompt
         the user and possible cancel closing."""

--- a/dodo/mainwindow.py
+++ b/dodo/mainwindow.py
@@ -60,7 +60,6 @@ class MainWindow(QMainWindow):
                 self.app.panel_history.append(w)
                 # print("saving " + repr(w) + " to history")
                 w.setFocus()
-                if w.dirty: w.refresh()
 
         self.tabs.currentChanged.connect(panel_focused)
         self.show()

--- a/dodo/panel.py
+++ b/dodo/panel.py
@@ -97,6 +97,9 @@ class Panel(QWidget):
     def refresh(self) -> None:
         self.dirty = False
 
+    def update_thread(self, thread_id: str) -> None:
+        self.dirty = True
+
     def before_close(self) -> bool:
         """Called before closing a panel
 

--- a/dodo/panel.py
+++ b/dodo/panel.py
@@ -73,6 +73,11 @@ class Panel(QWidget):
 
         self._prefix_timer.timeout.connect(prefix_timeout)
 
+    def focusInEvent(self, event: PyQt6.QWidget.QFocusEvent):
+        super().focusInEvent(event)
+        if self.dirty:
+            self.refresh()
+
     def title(self) -> str:
         """The title shown on this panel's tab"""
 

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -433,6 +433,10 @@ class ThreadPanel(panel.Panel):
 
         super().refresh()
 
+    def update_thread(self, thread_id: str):
+        if self.model.thread_id == thread_id:
+            self.dirty = True
+
     def show_message(self, i: int=-1) -> None:
         """Show a message
 
@@ -523,7 +527,7 @@ class ThreadPanel(panel.Panel):
                 tag_expr = '+' + tag_expr
             r = subprocess.run(['notmuch', 'tag'] + tag_expr.split() + ['--', 'id:' + m['id']],
                     stdout=subprocess.PIPE)
-            self.app.refresh_panels()
+            self.app.update_single_thread(self.thread_id)
 
     def toggle_html(self) -> None:
         """Toggle between HTML and plain text message view"""

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -452,9 +452,7 @@ class ThreadPanel(panel.Panel):
             self.refresh()
             m = self.model.message_at(self.current_message)
             if 'unread' in m['tags']:
-                # this might change the filename, so we should refresh the model
                 self.tag_message('-unread')
-                self.refresh()
                 m = self.model.message_at(self.current_message)
 
             self.message_handler.message_json = m


### PR DESCRIPTION
Updating the entire search panel when touching any piece of data is
really costly, which is presumably why we only do it on the currently
active one and will only refresh the other ones when we focus them.

This patch allows for a more granular approach to refreshes, with an API
that specifies which thread has been updated. Each panel can then either
update their own data model (if known to be relevant, e.g. the thread is
already in the search results, and it is cheap enough to do it right
away), mark itself as dirty to fall back on the previous global
behaviour, or ignore the update entirely (relevant for Thread panels).

It's an actual pain point when sorting through big searches, where
removing a single thread from the search can be really sluggish.

Also thrown in is the removal of a redundant refresh call when opening an unread message in Thread.