### PR TITLE
app: initiate a background sync at startup

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -100,6 +100,7 @@ class Dodo(QApplication):
 
         # set timer to sync email periodically
         if settings.sync_mail_interval != -1:
+            self.sync_mail()
             timer = QTimer(self)
             timer.timeout.connect(self.sync_mail)
             timer.start(settings.sync_mail_interval * 1000)


### PR DESCRIPTION
If I configure my MUA to do regular syncs, I'd expect that first sync to happen at startup *and then* each $time_period. It's especially painful when the first sync of the day is a bit long, as both delays compound while you stare blankly at your stale inbox, waiting for your morning coffee to kick in.