### PR TITLE
thread: restore collapsed state before reselecting the message

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -546,6 +546,13 @@ class ThreadPanel(panel.Panel):
             self._saved_collapsed = self._get_collapsed()
 
     def _do_reset(self):
+        if self._saved_collapsed is None:
+            collapsed = self.model.default_collapsed()
+        else:
+            collapsed = self._saved_collapsed
+            self._saved_collapsed = None
+        self._restore_collapsed(collapsed)
+
         idx = QModelIndex()
         if self._saved_msg:
             idx = self.model.find(self._saved_msg)
@@ -554,12 +561,6 @@ class ThreadPanel(panel.Panel):
             self._select_index(idx)
         else:
             self._select_index(self.model.default_message())
-        if self._saved_collapsed is None:
-            collapsed = self.model.default_collapsed()
-        else:
-            collapsed = self._saved_collapsed
-            self._saved_collapsed = None
-        self._restore_collapsed(collapsed)
 
     def toggle_list_mode(self):
         self.model.toggle_mode()


### PR DESCRIPTION
Collapsing causes the scroll position to be reset, which the reselecting will restore. As a bonus, it seems the framework is smart enough to not move the scroll position *at all* since both operations are presumably done within one rendering pass.

It will still snap back to the selected message if the user happened to have scrolled to a position where it wasn't visible before the sync, but I still consider this a more sensible behaviour than moving back to the top.