### PR TITLE
Improve output on send exception

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -31,6 +31,7 @@ import email.policy
 import email.message
 import mimetypes
 import subprocess
+import traceback
 from subprocess import PIPE, Popen, TimeoutExpired
 import tempfile
 import typing
@@ -460,4 +461,6 @@ class SendmailThread(QThread):
         except TimeoutExpired:
             self.panel.status = f'<i style="color:{settings.theme["fg_bad"]}">timed out</i>'
         except Exception as e:
-            self.panel.status = f'<i style=f"color:{settings.theme["fg_bad"]}">exception {e}</i>'
+            msg = util.simple_escape(str(e))
+            self.panel.status = f'<i style="color:{settings.theme["fg_bad"]}">exception {msg} (traceback on stderr)</i>'
+            traceback.print_exc()


### PR DESCRIPTION
- Fix the stray "f" inside the string breaking the color
- Don't hide the traceback from the user, as it's impossible to track down issues without it ("exception: None"?!)
- HTML escape the exception message - while somewhat unlikely, it could contain HTML characters.

In my case, I had a:

```python
Traceback (most recent call last):
  File "/home/florian/proj/dodo/dodo/compose.py", line 428, in run
    eml = pgp_util.sign(eml)
          ^^^^^^^^^^^^^^^^^^
  File "/home/florian/proj/dodo/dodo/pgp_util.py", line 65, in sign
    signed_mail.set_param("micalg", 'pgp-' + RFC4880_HASH_ALGO[sig.hash_algo].lower())
                                             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: None
```

which only showed me `Exception: None`.