### PR TITLE
Use raw strings for all regex patterns

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -197,7 +197,7 @@ class RemoteBlockingUrlRequestInterceptor(QWebEngineUrlRequestInterceptor):
         if info.requestUrl().scheme() not in app.LOCAL_PROTOCOLS:
             info.block(settings.html_block_remote_requests)
 
-RE_REGEX = re.compile('^R[Ee]: ')
+RE_REGEX = re.compile(r'^R[Ee]: ')
 class ThreadItem:
     def __init__(self, raw_data, parent: ThreadItem|None):
         self.msg = raw_data[0]

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -262,8 +262,8 @@ def strip_email_address(e: str) -> str:
     """
 
     # TODO proper handling of quoted strings
-    head = re.compile('^.*<')
-    tail = re.compile('>.*$')
+    head = re.compile(r'^.*<')
+    tail = re.compile(r'>.*$')
     return tail.sub('', head.sub('', e))
 
 def email_is_me(e: str) -> bool:
@@ -346,7 +346,7 @@ def replace_header(s: str, h: str, new_value: str) -> str:
     Note this ONLY works for short (i.e. unwrapped) headers."""
 
     (headers, body) = separate_headers(s)
-    old_h = re.compile('^' + h + ':.*$', re.MULTILINE)
+    old_h = re.compile(r'^' + h + r':.*$', re.MULTILINE)
     headers = old_h.sub(h + ': ' + new_value, headers)
 
     return headers + '\n' + body


### PR DESCRIPTION
See https://docs.python.org/3/library/re.html#raw-string-notation

Even if those patterns do not contain any backslashes, it is a good practice to use raw strings for all regex patterns, to avoid footguns when changing the patterns in the future.

Also see 93244ad9960490d4ad4e12f1466e02714ef18930 where this did already cause a SyntaxWarning before.