### PR TITLE
Implement per-tag color overrides

### DIFF
--- a/dodo/search.py
+++ b/dodo/search.py
@@ -131,6 +131,11 @@ class SearchModel(QAbstractItemModel):
                 font.setBold(True)
             return font
         elif role == Qt.ItemDataRole.ForegroundRole:
+            for tag in settings.search_color_overrides.keys() & thread_d['tags']:
+                if col in settings.search_color_overrides[tag]:
+                    color = settings.search_color_overrides[tag][col]
+                    return QColor(color)
+
             color = 'fg_' + col
             unread_color = 'fg_' + col + '_unread'
             flagged_color = 'fg_' + col + '_flagged'

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -338,3 +338,26 @@ Example configuration using this feature to highlight markdown syntax:
   pygments_css = pygments.formatters.HtmlFormatter(style="gruvbox-dark").get_style_defs()
   dodo.settings.message_css += pygments_css.replace("{", "{{").replace("}", "}}")
 """
+
+search_color_overrides = {}
+"""A dictionary mapping tags to color dictionaries.
+
+The color dictionaries map columns to override colors.
+The available columns are:
+
+- date
+- from
+- subject
+- tags
+
+For example, to show a red subject for messages tagged 'urgent',
+using the built-in Gruvbox palette:
+
+.. code-block:: python
+
+  dodo.settings.search_color_overrides = {
+      'urgent': {
+          'subject': dodo.themes.gruvbox_p['neutral_red'],
+      }
+  }
+"""


### PR DESCRIPTION
In my config, I use

```python
def apply_done(p):
    subprocess.run("notmuch tag -inbox -inbox/done -unread tag:inbox/done".split())
    p.refresh()


def toggle_done(p):
    p.toggle_thread_tag("inbox/done")
    p.next_thread()


dodo.keymap.search_keymap["d"] = ("mark done", toggle_done)
dodo.keymap.search_keymap["$"] = ("apply done", apply_done)


dodo.settings.search_color_overrides = {
    "inbox/done": {"subject": dodo.themes.gruvbox_p["dark2"]},
}
```

Which allows me to have a workflow similar to what I had in neomutt, where `d` only marks a message as "done", and then later pressing `$` actually removes the `inbox` tag:

![image](https://github.com/user-attachments/assets/ea3edce3-d4f2-435b-ae09-4a36e1bd4a03)
