### PR TITLE
Use notmuch to get attachment contents

### DIFF
--- a/dodo/util.py
+++ b/dodo/util.py
@@ -252,26 +252,21 @@ def write_attachments(m: dict) -> Tuple[str, List[str]]:
               returns an empty string and empty list.
     """
 
-    if not (m and 'filename' in m): return ('', [])
+    if not m: return ('', [])
     temp_dir = tempfile.mkdtemp(prefix='dodo-')
     file_paths = []
 
-    for filename in m['filename']:
-        with open(filename, 'r') as f:
-            msg = email.message_from_file(f,policy=email.policy.default)
-            for part in msg.walk():
-                if not part.is_attachment():
-                    continue
-                filename = part.get_filename()
-                p = temp_dir + '/' + decode_header(filename)
-                contents = part.get_content()
-                # Write back text files using their original encoding,
-                # for the rest use straight binary encoding
-                if isinstance(contents, str):
-                    contents = contents.encode(part.get_content_charset('ascii').lower())
-                with open(p, 'wb') as att:
-                    att.write(contents)
-                file_paths.append(p)
+    for part in message_parts(m):
+        if part.get("content-disposition") == "attachment":
+            proc = subprocess.run(
+                ["notmuch", "show", "--part", str(part["id"]), "--", "id:" + m["id"]],
+                capture_output=True,
+                check=True,
+            )
+            p = temp_dir + '/' + part["filename"]
+            with open(p, 'wb') as att:
+                att.write(proc.stdout)
+            file_paths.append(p)
 
     if len(file_paths) == 0:
         os.rmdir(temp_dir)


### PR DESCRIPTION
Simplifies the code and works with PGP encrypted messages (where the previous logic did not find any attachments).

Due to letting notmuch handle the attachment extraction, this should hopefully also supersede #53 without regressing. Unfortunately I was unable to replicate the issue described there, even with a long attachment filename and that commit reverted.

@hbog do you perhaps still have the mail that prompted that bugfix, so you could double-check that it works fine after my change still? (we should probably have an automated testsuite for Dodo at some point, but that's a whole chapter on its own...)