### PR TITLE
Add settings.html_confirm_open_links_trusted_hosts

### DIFF
--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -194,6 +194,13 @@ the web browser will request before opening. This is an extra measure against ph
 or emails opening your web browser without your permission.
 """
 
+html_confirm_open_links_trusted_hosts = []
+"""A list of trusted hosts for HTML links.
+
+If a link is to a host in this list, it will be opened without confirmation, even if
+:func:`~dodo.settings.html_confirm_open_links` is True.
+"""
+
 # visual
 theme = themes.nord
 """The GUI theme

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -91,6 +91,7 @@ class MessagePage(QWebEnginePage):
                     self.app.open_compose(mode='mailto', msg=msg)
                 else:
                     if (not settings.html_confirm_open_links or
+                        url.host() in settings.html_confirm_open_links_trusted_hosts or
                         QMessageBox.question(None, 'Open link',
                             f'Open the following URL in browser?\n\n  {url.toString()}') == QMessageBox.StandardButton.Yes):
                         if settings.web_browser_command == '':


### PR DESCRIPTION
If a link is to a host in this list, it will be opened without confirmation, even if
`dodo.settings.html_confirm_open_links` is True.

Using this e.g. for `github.com` as I get lots of GitHub notifications and consider that a safe host when clicking links that go there, yet would still be notified with the exact target when I click on something more exotic.