### PR TITLE
Show message ID in thread view

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -666,6 +666,12 @@ class ThreadPanel(panel.Panel):
                   <td><b style="color: {settings.theme["fg_bright"]}">Decryption:&nbsp;</b></td>
                   <td>{m['crypto']['decrypted']['status']}"""
                 header_html += "</td></tr>"
+
+            # Show message id
+            header_html += f"""<tr>
+              <td><b style="color: {settings.theme["fg_bright"]}">Id:&nbsp;</b></td>
+              <td>{util.simple_escape(m["id"])}</td>
+            </tr>"""
             header_html += '</table>'
             self.message_info.setHtml(header_html)
 


### PR DESCRIPTION
Useful for debugging when wanting to see a message via `notmuch`, but personally I also sometimes use this when I need a nice identifier for a message otherwise (e.g. on a todo-list).

![image](https://github.com/user-attachments/assets/7290a854-2e28-489c-a49d-a27f30b391ff)

Perhaps at some point we should make it configurable what the user actually wants to show in there? But IMHO it doesn't hurt much to just always show it.