### PR TITLE
Fix crash on empty search query

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -176,6 +176,8 @@ class Dodo(QApplication):
 
         If a panel with this query is already open, switch to it rather than
         opening another copy."""
+        if not query:
+            return
 
         for i in range(self.num_panels()):
             w = self.tabs.widget(i)


### PR DESCRIPTION
With a trivial "/, Enter", Dodo crashes with:

    Error: notmuch search requires at least one search term.

    Traceback (most recent call last):
      [...]
      File ".../dodo/search.py", line 54, in refresh
        self.d = json.loads(self.json_str)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
      [...]
      File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
        raise JSONDecodeError("Expecting value", s, err.value) from None
    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Given that only an empty search should be able to trigger such an error, it seems sensible for an enter press without input to just close the command bar again.