### PR TITLE
Add tooltips for tags

### DIFF
--- a/dodo/search.py
+++ b/dodo/search.py
@@ -142,6 +142,8 @@ class SearchModel(QAbstractItemModel):
                 return QColor(settings.theme[color])
             else:
                 return QColor(settings.theme['fg'])
+        elif role == Qt.ItemDataRole.ToolTipRole and col == 'tags':
+            return ' '.join(thread_d['tags'])
 
     def headerData(self, section: int, orientation: Qt.Orientation, role: int=Qt.ItemDataRole.DisplayRole) -> Any:
         """Overrides `QAbstractItemModel.headerData` to populate a view with column names"""

--- a/dodo/themes.py
+++ b/dodo/themes.py
@@ -325,7 +325,7 @@ def apply_theme(theme: dict) -> None:
     palette.setColor(QPalette.ColorRole.WindowText, QColor(theme['fg']))
     palette.setColor(QPalette.ColorRole.Base, QColor(theme['bg']))
     palette.setColor(QPalette.ColorRole.AlternateBase, QColor(theme['bg_alt']))
-    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(theme['fg']))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(theme['bg']))
     palette.setColor(QPalette.ColorRole.ToolTipText, QColor(theme['fg']))
     palette.setColor(QPalette.ColorRole.Text, QColor(theme['fg']))
     palette.setColor(QPalette.ColorRole.Button, QColor(theme['bg_button']))


### PR DESCRIPTION
Useful when configuring a lot of tag_icons but still wanting to see the underlying tag.

Also includes hidden tags.

![image](https://github.com/user-attachments/assets/3a21c365-6190-4d17-8f63-a41cbc6eaa63)
