### PR TITLE
Add debugging information to asserts

### DIFF
--- a/dodo/search.py
+++ b/dodo/search.py
@@ -62,7 +62,7 @@ class SearchModel(QAbstractItemModel):
         else:
             thread_id = self.thread_id(thread)
             row = thread.row()
-            assert(thread_id is not None)
+            assert thread_id is not None
 
         r = subprocess.run(['notmuch', 'search', '--format=json', f'{self.q} AND thread:{thread_id}'],
                 stdout=subprocess.PIPE)

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -304,7 +304,7 @@ class ThreadModel(QAbstractItemModel):
         logger.info("Full thread refresh")
         matches = self._fetch_matching_ids()
         data = self._fetch_full_thread()
-        assert(len(data) == 1)
+        assert len(data) == 1, data
         data = data[0]
         roots = self.compute_roots(data)
         self.beginResetModel()
@@ -315,7 +315,7 @@ class ThreadModel(QAbstractItemModel):
 
     def refresh_message(self, msg_id: str):
         idx = self.find(msg_id)
-        assert idx.isValid()
+        assert idx.isValid(), msg_id
         logger.info("Single message refresh: %s", msg_id)
         r = subprocess.run(['notmuch', 'show', '--entire-thread=false', '--exclude=false', '--format=json', '--verify', '--include-html', '--decrypt=true', f'id:{msg_id}'],
                 stdout=subprocess.PIPE, encoding='utf8')
@@ -366,7 +366,7 @@ class ThreadModel(QAbstractItemModel):
 
     def message_at(self, idx: QModelIndex) -> dict:
         """A JSON object describing the i-th message in the (flattened) thread"""
-        assert idx.isValid()
+        assert idx.isValid(), idx
         return idx.internalPointer().msg
 
     def _children_at(self, idx: QModelIndex) -> list[ThreadItem]:

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -312,7 +312,7 @@ def email_smtp_account_index(e: str) -> Optional[int]:
     select the account to be used when replying to a mail. It returns the index
     of first matching account or None if provided email does not match
     any smtp account.  """
-    assert isinstance(settings.email_address, dict)
+    assert isinstance(settings.email_address, dict), settings.email_address
     return next(
             (i for i, acc in enumerate(settings.smtp_accounts) if
              strip_email_address(e) ==


### PR DESCRIPTION
Python allows adding additional information after an assert, which is printed when it fails.

I've had `assert len(data) == 1` failing, but without knowing what the actual data was, this is impossible to debug (and it wasn't reproducible).

Also unifies the syntax to use `assert condition` instead of `assert(condition)`, as is commonly done in Python (like with e.g. `return` or `if`).