### PR TITLE
sendmail: use different commands for different accounts

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -420,7 +420,11 @@ class SendmailThread(QThread):
             if self.panel.pgp_sign:
                 eml = pgp_util.sign(eml)
 
-            cmd = settings.send_mail_command.replace('{account}', account)
+            if isinstance(settings.send_mail_command, dict):
+                cmd = settings.send_mail_command[account]
+            else:
+                cmd = settings.send_mail_command
+            cmd = cmd.replace('{account}', account)
             sendmail = Popen(cmd, stdin=PIPE, encoding='utf8', shell=True)
             if sendmail.stdin:
                 sendmail.stdin.write(eml.as_string())

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -93,13 +93,16 @@ is an empty string, Dodo will attempt to use the default web browser supplied by
 the desktop environment, if it exists.
 """
 
-send_mail_command = 'msmtp -a "{account}" -t'
+send_mail_command: str | dict[str, str] = 'msmtp -a "{account}" -t'
 """Command used to send mail via SMTP
 
-This is a shell command that expects a (sendmail-compatible) email message to be
-written to STDIN. Note that it should read the destination from the `From:` header
-of the message and not a command-line argument. Use the `{account}` placeholder
-to read the currently selected account.
+Either a plain command or a mapping of account names to command.
+
+The command must be a shell command that expects a (sendmail-compatible) email
+message to be written to STDIN. Note that it should read the destination from
+the `From:` header of the message and not a command-line argument. Use the
+`{account}` placeholder to read the currently selected account.
+
 """
 
 smtp_accounts = ['default']


### PR DESCRIPTION
I have a fairly weird setup where SMTP isn't possible for all my aliases. I could either write a wrapper around those commands or do this, and this seems less error-prone than dealing with escaping arguments and forwarding file descriptors.