### PR TITLE
GPG: First sign, then encrypt

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -414,11 +414,11 @@ class SendmailThread(QThread):
                 except IOError:
                     print("Can't read attachment: " + att)
 
-            if self.panel.pgp_encrypt:
-                eml = pgp_util.encrypt(eml)
-
             if self.panel.pgp_sign:
                 eml = pgp_util.sign(eml)
+
+            if self.panel.pgp_encrypt:
+                eml = pgp_util.encrypt(eml)
 
             cmd = settings.send_mail_command.replace('{account}', account)
             sendmail = Popen(cmd, stdin=PIPE, encoding='utf8', shell=True)

--- a/dodo/pgp_util.py
+++ b/dodo/pgp_util.py
@@ -77,7 +77,7 @@ def sign(msg: email.message.EmailMessage) -> email.message.EmailMessage:
     msg_to_sign = email.message_from_string(msg.as_string(), policy=gpg_policy)
     # Create a new mail that will contain the original message and its signature
     signed_mail = email.message.EmailMessage(policy=msg.policy.clone(linesep='\r\n'))
-    # copy the non Content-* headers to the new mail and remove them form the
+    # copy the non Content-* headers to the new mail and remove them from the
     # message that will be signed
     for k, v in msg.items():
         if not k.lower().startswith('content-'):
@@ -119,7 +119,7 @@ def encrypt(msg: email.message.EmailMessage) -> email.message.EmailMessage:
     # the original message (msg) unaltered.
     msg_to_encrypt = email.message_from_bytes(msg.as_bytes(), policy=msg.policy.clone())
     # Create a new message that will contain the control part and the encrypted
-    # message. Copy the non Content-* headers and remove them form the
+    # message. Copy the non Content-* headers and remove them from the
     # message that will be encrypted
     encrypted_mail = email.message.EmailMessage(policy=msg.policy.clone())
     for k, v in msg.items():
@@ -141,10 +141,10 @@ def encrypt(msg: email.message.EmailMessage) -> email.message.EmailMessage:
     raise_for_status(encrypted_contents)
 
     # attach the ASCII representation of the encrypted test, note that
-    # set_content with contaent-type other then text requires a bytes object
+    # set_content with content-type other then text requires a bytes object
     pgp_encrypted_part = email.message.EmailMessage()
     pgp_encrypted_part.set_content(str(encrypted_contents).encode(), 'application',
                                    'octet-stream', disposition='inline',
-                                   filename='encrypred.asc', cte='7bit')
+                                   filename='encrypted.asc', cte='7bit')
     encrypted_mail.attach(pgp_encrypted_part)
     return encrypted_mail


### PR DESCRIPTION
This seems to be what GPG itself does:
https://superuser.com/questions/979070/sign-encrypt-vs-encrypt-sign-what-does-gpg-do/979071#979071

Encrypting and then signing seems to be allowed in theory, but quite uncommon in practice.

Before this change, when running gpg --decrypt on a signed + encrypted .eml as produced by Dodo, it doesn't know what to do with the signature:

    Detached signature.
    Please enter name of data file:

More importantly, Thunderbird seems to have trouble handling attachments and replying for such mails coming from Dodo:

https://bugzilla.mozilla.org/show_bug.cgi?id=1952934

Also fixing some typos I found while investigating this.