### PR TITLE
Improve attachment handling

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -646,8 +646,11 @@ class ThreadPanel(panel.Panel):
                   <td><b style="color: {settings.theme["fg_bright"]}">Tags:&nbsp;</b></td>
                   <td><span style="color: {settings.theme["fg_tags"]}; font-family: {settings.tag_font}; font-size: {settings.tag_font_size}">{tags}</span></td>
                 </tr>"""
-            attachments = [f'[{part["filename"]}]' for part in util.message_parts(m)
-                    if part.get('content-disposition') == 'attachment' and 'filename' in part]
+            attachments = [
+                f"[{part['filename']}]"
+                for part in util.message_parts(m)
+                if util.is_attachment(part)
+            ]
 
             if len(attachments) != 0:
                 header_html += f"""<tr>


### PR DESCRIPTION
- Don't store PGP signatures as attachments
- Treat binary parts without content-disposition as attachments (fixes #93)
- Add utility function to ensure handling between different UI parts is consistent
- Make sure encrypted attachments are always decrypted
- Ensure stderr from notmuch gets shown in the terminal
- Don't silently save empty files on errors (notmuch still seems to exit 0 on e.g. decryption failures...)
- Use os.path.join instead of hardcoding path separators