### PR TITLE
Fix add_header_line to preserve empty line

### DIFF
--- a/dodo/util.py
+++ b/dodo/util.py
@@ -351,7 +351,7 @@ def add_header_line(s: str, h: str) -> str:
     blank line, in the provided string."""
 
     (headers, body) = separate_headers(s)
-    return headers + h + '\n' + body
+    return headers + h + '\n\n' + body
 
 def replace_header(s: str, h: str, new_value: str) -> str:
     """Replace a single header without doing full message parsing


### PR DESCRIPTION
Otherwise the empty line after headers gets lost when attaching the first file, and thus the distinction between headers/body does.

See previous discussion in #50, IMHO this is the more proper place to fix this, as add_header_line now properly does what the name and docstring suggest.