### PR TITLE
thread: allow duplicate tabs when the query is different

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -197,7 +197,7 @@ class Dodo(QApplication):
 
         for i in range(self.num_panels()):
             w = self.tabs.widget(i)
-            if isinstance(w, thread.ThreadPanel) and w.thread_id == thread_id:
+            if isinstance(w, thread.ThreadPanel) and (w.thread_id, w.query) == (thread_id, query):
                 self.tabs.setCurrentIndex(i)
                 return
 

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -492,6 +492,7 @@ class ThreadPanel(panel.Panel):
         self.set_keymap(keymap.thread_keymap)
         self.model = ThreadModel(thread_id, search_query, settings.default_thread_list_mode)
         self.thread_id = thread_id
+        self.query = search_query
         self.html_mode = settings.default_to_html
         self._saved_msg = None
         self._saved_collapsed = None


### PR DESCRIPTION
Otherwise you get pretty weird results if you open threads from two *very different* queries, as the folding rules and graying out will still use the initial query.