### PR TITLE
thread: use a fallback when parseaddr chokes

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -216,7 +216,10 @@ class ThreadItem:
         from_hdr = self.msg.get('headers', {}).get('From', '(message) <>')
         name, addr = email.utils.parseaddr(from_hdr)
         if not name:
-            name = addr
+            if addr:
+                name = addr
+            else: # notmuch preprocesses headers, making parseaddr choke on edge cases
+                name = from_hdr
         if not self.parent:
             return name
 


### PR DESCRIPTION
There are cases where parseaddr would fail on an address that *after processing* contains a comma, yet the raw string doesn't. For instance, something like

From: =?UTF-8?B?Tm9tLCBQcsOpbm9t?= <foo@example.com>

is RFC compliant, yet notmuch helpfully decodes this into "Nom, prénom <foo@example.com>" which of course parseaddr chokes on.

AFAICT there is no good way of fixing this so instead we just output the entire string if all else fails.