### PR TITLE
Drop redundant `wheel` from PEP 517 definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It used to be a mistake in the `setuptools`' docs for a while but I've corrected it over there long ago. Sadly, many projects have been copying the snippet all over religiously.

Old versions of `setuptools` depend on `wheel` when building wheels (but not sdists!). But the respective mechanism has been migrated from `wheel` (the project) into `setuptools` at last year's PyCon US (mostly by the maintainer, I helped a bit too). And so now everything is bundled.

To summarize, this was never needed but going forward it's got all chances of becoming problematic in time.