### PR TITLE
Fix AttributeError on notmuch errors

### DIFF
--- a/dodo/search.py
+++ b/dodo/search.py
@@ -60,7 +60,7 @@ class SearchModel(QAbstractItemModel):
             self.error_msg = None
         except subprocess.CalledProcessError as e:
             # We keep the previous data, just add an error message on top.
-            self.error_msg = e.stderr.decode()
+            self.error_msg = e.stderr
         self.threads = {thread['thread']: i for i,thread in enumerate(self.d)}
         self.num_threads = len(self.d)
         self.endResetModel()
@@ -89,7 +89,7 @@ class SearchModel(QAbstractItemModel):
             self.threads = {thread['thread']: i for i,thread in enumerate(self.d)}
             self.num_threads = len(self.d)
         except subprocess.CalledProcessError as e:
-            self.error_msg = e.stderr.decode()
+            self.error_msg = e.stderr
         self.endResetModel()
         logger.info("Model refreshed for '%s'", self.q)
 

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -60,7 +60,7 @@ class SearchModel(QAbstractItemModel):
             self.error_msg = None
         except subprocess.CalledProcessError as e:
             # We keep the previous data, just add an error message on top.
-            self.error_msg = e.stderr
+            self.error_msg = f"notmuch: {e.stderr}"
         self.threads = {thread['thread']: i for i,thread in enumerate(self.d)}
         self.num_threads = len(self.d)
         self.endResetModel()
@@ -89,7 +89,7 @@ class SearchModel(QAbstractItemModel):
             self.threads = {thread['thread']: i for i,thread in enumerate(self.d)}
             self.num_threads = len(self.d)
         except subprocess.CalledProcessError as e:
-            self.error_msg = e.stderr
+            self.error_msg = f"notmuch: {e.stderr}"
         self.endResetModel()
         logger.info("Model refreshed for '%s'", self.q)
 


### PR DESCRIPTION
This was added in 9a6dc597aa7473e5e9773ac7a5f1d5e51d62a86c together with passing `text=True` to `subprocess.run()`.

However, with `text=True`, `CalledProcessError.stderr` is also already `str`, not `bytes`.

Thanks to @omega-800 for spotting this!

cc @laarmen 