### PR TITLE
Allow setting gnupg_keyid per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ del dodo.keymap.global_keymap['Q']
 
 ### Multiple accounts
 
-If you are using something like [msmtp](https://marlam.de/msmtp/) to send emails, it is possible to send mail from multiple accounts. To set this up, simply set a list of account names your SMTP client recognises in `config.py`. You can also provide per-account email addresses and sent directories by passing dictionaries to `email_address` and `sent_dir` settings, respectively.
+If you are using something like [msmtp](https://marlam.de/msmtp/) to send emails, it is possible to send mail from multiple accounts. To set this up, simply set a list of account names your SMTP client recognises in `config.py`. You can also provide per-account email addresses and sent directories by passing dictionaries to `email_address` and `sent_dir` settings, respectively. The `gnupg_keyid` setting can also be set to a dictionary mapping account names to GPG key IDs. If an account name is missing, signing is automatically disabled when switching to the account in question.
 
 ```python
 import dodo

--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -70,7 +70,6 @@ class ComposePanel(panel.Panel):
         self.layout().addWidget(self.message_view)
         self.status = f'<i style="color:{settings.theme["fg"]}">draft</i>'
         self.current_account = 0
-        self.pgp_sign = settings.gnupg_keyid is not None
         self.pgp_encrypt = False
         self.wrap_message = settings.wrap_message
 
@@ -97,6 +96,7 @@ class ComposePanel(panel.Panel):
         else:
             self.current_account = 0
 
+        self.pgp_sign = self.gnupg_keyid() is not None
         self.raw_message_string = f'From: {self.email_address()}\n'
 
         if msg and mode == 'mailto':
@@ -260,13 +260,20 @@ class ComposePanel(panel.Panel):
 
     def toggle_pgp_sign(self) -> None:
         # Silently ignore when gnupg_keyid is not set
-        if not settings.gnupg_keyid: return
+        if not self.gnupg_keyid(): return
         self.pgp_sign = True if self.pgp_sign is False else False
         self.refresh()
 
     def toggle_pgp_encrypt(self) -> None:
         self.pgp_encrypt = True if self.pgp_encrypt is False else False
         self.refresh()
+
+    def gnupg_keyid(self) -> str | None:
+        """Get the GPG key id to use based on the current SMTP account."""
+        if isinstance(settings.gnupg_keyid, dict):
+            return settings.gnupg_keyid.get(self.account_name())
+        else:
+            return settings.gnupg_keyid
 
     def account_name(self) -> str:
         """Return the name of the current SMTP account"""
@@ -290,6 +297,7 @@ class ComposePanel(panel.Panel):
         if self.email_address() != old_email:
             self.raw_message_string = util.replace_header(self.raw_message_string, 'From', self.email_address())
 
+        self.pgp_sign = self.gnupg_keyid() is not None
         self.refresh()
 
     def previous_account(self) -> None:
@@ -301,6 +309,7 @@ class ComposePanel(panel.Panel):
         if self.email_address() != old_email:
             self.raw_message_string = util.replace_header(self.raw_message_string, 'From', self.email_address())
 
+        self.pgp_sign = self.gnupg_keyid() is not None
         self.refresh()
 
     def send(self) -> None:
@@ -419,7 +428,7 @@ class SendmailThread(QThread):
                     print("Can't read attachment: " + att)
 
             if self.panel.pgp_sign:
-                eml = pgp_util.sign(eml)
+                eml = pgp_util.sign(eml, self.panel.gnupg_keyid())
 
             if self.panel.pgp_encrypt:
                 eml = pgp_util.encrypt(eml)

--- a/dodo/pgp_util.py
+++ b/dodo/pgp_util.py
@@ -61,7 +61,7 @@ def raise_for_status(result: GpgResult) -> None:
     raise GpgError(message)
 
 
-def sign(msg: email.message.EmailMessage) -> email.message.EmailMessage:
+def sign(msg: email.message.EmailMessage, keyid: str) -> email.message.EmailMessage:
     ensure_gpg()
     assert Gpg is not None  # for mypy
 
@@ -89,7 +89,7 @@ def sign(msg: email.message.EmailMessage) -> email.message.EmailMessage:
     # Attach the message to be signed
     signed_mail.attach(msg_to_sign)
     # Create the signature
-    sig = Gpg.sign(msg_to_sign.as_string(), keyid=settings.gnupg_keyid, detach=True)
+    sig = Gpg.sign(msg_to_sign.as_string(), keyid=keyid, detach=True)
     raise_for_status(sig)
     # Attach the ASCII representation (as per rfc) of the signature, note that
     # set_content with contaent-type other then text requires a bytes object


### PR DESCRIPTION
Like with other settings, gnupg_keyid can now be a dict mapping account names to key IDs. If an account name is missing, signing automatically gets disabled when switching to that account.