### PR TITLE
Remove exception handling when reading attachments

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -411,12 +411,9 @@ class SendmailThread(QThread):
                 else:
                     ty = ['application', 'octet-stream']
 
-                try:
-                    with open(os.path.expanduser(att), 'rb') as f1:
-                        data = f1.read()
-                        eml.add_attachment(data, maintype=ty[0], subtype=ty[1], filename=os.path.basename(att))
-                except IOError:
-                    print("Can't read attachment: " + att)
+                with open(os.path.expanduser(att), 'rb') as f1:
+                    data = f1.read()
+                    eml.add_attachment(data, maintype=ty[0], subtype=ty[1], filename=os.path.basename(att))
 
             if self.panel.pgp_sign:
                 eml = pgp_util.sign(eml)


### PR DESCRIPTION
We already have an "except Exception:" which displays an error in the UI. With this additional handling, the mail gets sent but simply without attachment, with nothing obvious telling the user what happened.