### PR TITLE
RFC: Add inline PGP support

### DIFF
--- a/dodo/pgp_util.py
+++ b/dodo/pgp_util.py
@@ -33,6 +33,10 @@ except (ImportError, NameError):
     Gpg = None
 
 
+INLINE_BEGIN = "-----BEGIN PGP MESSAGE-----\n"
+INLINE_END = "\n-----END PGP MESSAGE-----"
+
+
 class GpgError(Exception):
     pass
 
@@ -148,3 +152,15 @@ def encrypt(msg: email.message.EmailMessage) -> email.message.EmailMessage:
                                    filename='encrypted.asc', cte='7bit')
     encrypted_mail.attach(pgp_encrypted_part)
     return encrypted_mail
+
+
+def maybe_decrypt_inline(contents: str) -> str:
+    stripped = contents.strip("\n")
+    if not (stripped.startswith(INLINE_BEGIN) and stripped.endswith(INLINE_END)):
+        return contents
+
+    ensure_gpg()
+    assert Gpg is not None  # for mypy
+    decrypted = Gpg.decrypt(contents)
+    raise_for_status(decrypted)
+    return decrypted.data.decode()

--- a/dodo/pgp_util.py
+++ b/dodo/pgp_util.py
@@ -164,3 +164,13 @@ def maybe_decrypt_inline(contents: str) -> str:
     decrypted = Gpg.decrypt(contents)
     raise_for_status(decrypted)
     return decrypted.data.decode()
+
+
+def decrypt_inline_attachment(data: bytes) -> bytes:
+    ensure_gpg()
+    assert Gpg is not None  # for mypy
+
+    assert data.startswith(INLINE_BEGIN.encode()) and data.endswith(INLINE_END.encode())
+    decrypted = Gpg.decrypt(data)
+    raise_for_status(decrypted)
+    return decrypted.data

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -44,6 +44,7 @@ from . import settings
 from . import util
 from . import keymap
 from . import panel
+from . import pgp_util
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,9 @@ class MessageHandler(QWebEngineUrlSchemeHandler):
                     if text is not None:
                         break
                 else:
-                    text = util.simple_escape(util.body_text(self.message_json))
+                    text = util.body_text(self.message_json)
+                    text = pgp_util.maybe_decrypt_inline(text)
+                    text = util.simple_escape(text)
                     text = util.colorize_text(text)
                     text = util.linkify(text)
 

--- a/dodo/util.py
+++ b/dodo/util.py
@@ -37,6 +37,7 @@ from bleach.sanitizer import Cleaner
 from bleach.linkifier import Linker
 
 from . import settings
+from . import pgp_util
 
 def clean_html2html(s: str) -> str:
     """Sanitize the given HTML string
@@ -341,13 +342,19 @@ def write_attachments(m: dict) -> Tuple[str, List[str]]:
                 check=True,
             )
             filename = part["filename"]
-            if not proc.stdout:
+            data = proc.stdout
+
+            if not data:
                 print(f"Ignoring attachment {filename}: Got empty contents from notmuch")
                 continue
 
+            if filename.endswith(".pgp"):
+                filename = os.path.splitext(filename)[0]
+                data = pgp_util.decrypt_inline_attachment(data)
+
             p = os.path.join(temp_dir, sanitize_filename(filename))
             with open(p, 'wb') as att:
-                att.write(proc.stdout)
+                att.write(data)
             file_paths.append(p)
 
     if len(file_paths) == 0:


### PR DESCRIPTION
Unfortunately the weird corporate environment of a customer of mine can only send inline PGP mails. Sadly, proper support for that never made it into notmuch:

- [cope with inline PGP encrypted messages](https://nmbug.notmuchmail.org/nmweb/show/20171212071553.6440-1-dkg%40fifthhorseman.net)
- [#806796 - notmuch: no support for inline PGP - Debian Bug report logs](https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=806796)

This is somewhat of a hack, adding support for them inside Dodo, as we have all the building blocks to be able to at least display those messages (and attachments).

I have been running with this for a while now and it has made my life much easier. If you prefer, I can generalize this somehow (some sort of message/attachment filter function?), but this seemed simple enough to submit as-is.