### PR TITLE
Provide a mechanism to customize the default message selection

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -194,7 +194,7 @@ class Dodo(QApplication):
         p = search.SearchPanel(self, query, keep_open=keep_open)
         self.add_panel(p)
 
-    def open_thread(self, thread_id: str, query: str) -> None:
+    def open_thread(self, thread_id: str, query: str, default_message: thread.MessageSelector|None=None) -> None:
         """Open a thread panel with the given thread_id
 
         If a panel with this thread_id is already open, switch to it rather than
@@ -206,7 +206,7 @@ class Dodo(QApplication):
                 self.tabs.setCurrentIndex(i)
                 return
 
-        p = thread.ThreadPanel(self, thread_id, query)
+        p = thread.ThreadPanel(self, thread_id, query, default_message=default_message)
         self.add_panel(p)
 
     def open_compose(self, mode: str='', msg: Optional[dict]=None) -> None:

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -391,12 +391,12 @@ class SearchPanel(panel.Panel):
         pos = self.tree.rect().topLeft()
         self.tree.setCurrentIndex(self.tree.indexAt(pos))
 
-    def open_current_thread(self) -> None:
+    def open_current_thread(self, *, default_message: thread.MessageSelector|None=None) -> None:
         """Open the selected thread"""
 
         thread_id = self.model.thread_id(self.tree.currentIndex())
         if thread_id:
-            self.app.open_thread(thread_id, self.model.q)
+            self.app.open_thread(thread_id, self.model.q, default_message=default_message)
     
     def toggle_thread_tag(self, tag: str) -> None:
         """Toggle the given thread tag"""

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -450,7 +450,7 @@ class ThreadModel(QAbstractItemModel):
             msg = self.message_at(idx)
             if msg['id'] in self.matches and 'unread' in msg['tags']:
                 return idx
-        return QModelIndex()
+        return current
 
     def data(self, index: QModelIndex, role: int=Qt.ItemDataRole.DisplayRole) -> Any:
         """Overrides `QAbstractItemModel.data` to populate a list view with short descriptions of

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -17,8 +17,8 @@
 # along with Dodo. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from typing import List, Optional, Any, Union, Literal
-from collections.abc import Generator, Iterable
+from typing import List, Optional, Any, Union, Literal, TypeAlias
+from collections.abc import Generator, Iterable, Callable
 
 from PyQt6.QtCore import *
 from PyQt6.QtGui import QFont, QColor, QDesktopServices
@@ -502,6 +502,7 @@ class ThreadModel(QAbstractItemModel):
         """The number of rows (for a given parent)"""
         return len(self._children_at(parent))
 
+MessageSelector: TypeAlias = Callable[[ThreadModel], QModelIndex]
 
 class ThreadPanel(panel.Panel):
     """A panel showing an email thread
@@ -512,7 +513,7 @@ class ThreadPanel(panel.Panel):
     :param thread_id: the unique ID notmuch uses to identify this thread
     """
 
-    def __init__(self, a: app.Dodo, thread_id: str, search_query: str, parent: Optional[QWidget]=None):
+    def __init__(self, a: app.Dodo, thread_id: str, search_query: str, parent: Optional[QWidget]=None, default_message: MessageSelector|None=None):
         super().__init__(a, parent=parent)
         self.set_keymap(keymap.thread_keymap)
         self.model = ThreadModel(thread_id, search_query, settings.default_thread_list_mode)
@@ -521,6 +522,7 @@ class ThreadPanel(panel.Panel):
         self.html_mode = settings.default_to_html
         self._saved_msg = None
         self._saved_collapsed = None
+        self._default_message = default_message or (lambda m: m.default_message())
 
         self.subject = '(no subject)'
 
@@ -595,7 +597,7 @@ class ThreadPanel(panel.Panel):
         if idx.isValid():
             self._select_index(idx)
         else:
-            self._select_index(self.model.default_message())
+            self._select_index(self._default_message(self.model))
 
     def toggle_list_mode(self):
         self.model.toggle_mode()


### PR DESCRIPTION
This is my solution for #125. Not as elegant as my first solution to just call next_unread() on the panel once created, but that one had some issues when the thread was entirely unread, plus maybe some race condition somewhere for @klement. I'm wagering this version doesn't have the same issue.

Example binding that this allows:

```py
dodo.keymap.search_keymap['Q'] = ('open unread', lambda p: p.open_current_thread(default_message=lambda m: m.next_unread(m.default_message())))
```

I played around with it and it has handled anything I've thrown at it without crashing on me nor behaving weirdly.