### PR TITLE
Portable default settings

### DIFF
--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -35,6 +35,7 @@ defaults, as detailed below.
 
 from . import themes
 from typing import Literal, Dict, Union
+import sys
 
 # functional
 email_address: Union[str, Dict[str, str]] = ''
@@ -67,7 +68,8 @@ This is a shell command, which additionally takes the `{file}` placeholder,
 which is passed the name of a temp file being edited while composing an email.
 """
 
-file_browser_command = "nautilus '{dir}'"
+_open_command = "open" if sys.platform == "darwin" else "xdg-open"
+file_browser_command = f"{_open_command} '{dir}'"
 """Command used to launch external file browser
 
 This is a shell command, which additionally takes the `{dir}` placeholder. This

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -244,14 +244,14 @@ The following placeholders can be used:
 """
 
 tag_icons = {
-  'inbox': '',
-  'unread': '',
-  'attachment': '',
+  'inbox': '📥',
+  'unread': '✉',
+  'attachment': '📎',
   'sent': '>',
-  'replied': '',
-  'flagged': '',
-  'marked': '',
-  'signed': '',
+  'replied': '↩',
+  'flagged': '⚐',
+  'marked': '⏺',
+  'signed': '✎',
 }
 """Tag icons
 


### PR DESCRIPTION
Use more portable default settings: standard Unicode codepoints for tag icons, and the `open` command rather than Nautilus to see attachments. There is still the "writing an email" part that needs to be done, but that one is less easily solved I guess.