### PR TITLE
settings: expose message_zoom to control web view zoom factor

### DIFF
--- a/dodo/compose.py
+++ b/dodo/compose.py
@@ -66,7 +66,7 @@ class ComposePanel(panel.Panel):
         self.mode = mode
         self.msg = msg
         self.message_view = QWebEngineView()
-        self.message_view.setZoomFactor(1.2)
+        self.message_view.setZoomFactor(settings.message_zoom)
         self.layout().addWidget(self.message_view)
         self.status = f'<i style="color:{settings.theme["fg"]}">draft</i>'
         self.current_account = 0

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -231,6 +231,17 @@ message_font = 'DejaVu Sans Mono'
 message_font_size = 12
 """The font size used for plaintext messages"""
 
+message_zoom = 1.2
+"""Zoom factor for the message and compose web views
+
+QWebEngineView renders CSS ``pt`` sizes larger than QFont uses for the same
+point value in native Qt widgets (QTreeView, etc.), particularly on macOS
+Retina displays. This means the message body appears bigger than the thread
+list and header panels even when the configured font sizes match. Adjust
+this factor to compensate — values below 1.0 shrink the web view to better
+match the surrounding Qt widgets.
+"""
+
 search_view_padding = 1
 """A bit of spacing around each line in the search panel"""
 

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -557,7 +557,7 @@ class ThreadPanel(panel.Panel):
         self.message_view = QWebEngineView(self)
         page = MessagePage(self.app, self.message_profile, self.message_view)
         self.message_view.setPage(page)
-        self.message_view.setZoomFactor(1.2)
+        self.message_view.setZoomFactor(settings.message_zoom)
 
         self.layout_panel()
 


### PR DESCRIPTION
## Summary

Adds a `message_zoom` setting (default `1.0`) that lets users scale the zoom level of the HTML message viewer and the compose view.

This is useful on HiDPI displays or when the system font size differs from what the web engine assumes.

**Usage in `config.py`:**
```python
dodo.settings.message_zoom = 1.5
```

## Test plan
- [ ] Without setting, zoom level unchanged from current behaviour
- [ ] Set `message_zoom = 1.5` and verify message text is larger in thread and compose views