### PR TITLE
Font scaling for tab bar and column headers

### DIFF
--- a/dodo/mainwindow.py
+++ b/dodo/mainwindow.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 from PyQt6.QtCore import *
 from PyQt6.QtWidgets import *
-from PyQt6.QtGui import QIcon, QCloseEvent
+from PyQt6.QtGui import QFontMetrics, QIcon, QCloseEvent
 import logging
 import os
 
@@ -29,6 +29,15 @@ from . import panel
 from . import settings
 
 logger = logging.getLogger(__name__)
+
+class TabBar(QTabBar):
+    def tabSizeHint(self, index: int) -> QSize:
+        size = super().tabSizeHint(index)
+        fm = QFontMetrics(self.font())
+        min_height = fm.height() + 16
+        if size.height() < min_height:
+            size.setHeight(min_height)
+        return size
 
 class MainWindow(QMainWindow):
     def __init__(self, a: app.Dodo):
@@ -53,13 +62,15 @@ class MainWindow(QMainWindow):
 
         self.tabs = QTabWidget()
         self.tabs.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        tab_bar = TabBar()
+        self.tabs.setTabBar(tab_bar)
         if settings.tab_font or settings.tab_font_size:
-            f = self.tabs.tabBar().font()
+            f = tab_bar.font()
             if settings.tab_font:
                 f.setFamily(settings.tab_font)
             if settings.tab_font_size:
                 f.setPointSize(settings.tab_font_size)
-            self.tabs.tabBar().setFont(f)
+            tab_bar.setFont(f)
         # self.tabs.resize(1600, 800)
         w.layout().addWidget(self.tabs)
 

--- a/dodo/mainwindow.py
+++ b/dodo/mainwindow.py
@@ -26,6 +26,7 @@ import os
 from . import app
 from . import commandbar
 from . import panel
+from . import settings
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,13 @@ class MainWindow(QMainWindow):
 
         self.tabs = QTabWidget()
         self.tabs.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        if settings.tab_font or settings.tab_font_size:
+            f = self.tabs.tabBar().font()
+            if settings.tab_font:
+                f.setFamily(settings.tab_font)
+            if settings.tab_font_size:
+                f.setPointSize(settings.tab_font_size)
+            self.tabs.tabBar().setFont(f)
         # self.tabs.resize(1600, 800)
         w.layout().addWidget(self.tabs)
 

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -19,9 +19,9 @@
 from __future__ import annotations
 from typing import Optional, Any, overload, Literal
 
-from PyQt6.QtCore import Qt, QAbstractItemModel, QModelIndex, QObject, QSettings
-from PyQt6.QtWidgets import QTreeView, QWidget, QAbstractSlider, QVBoxLayout, QLabel
-from PyQt6.QtGui import QFont, QColor
+from PyQt6.QtCore import Qt, QSize, QAbstractItemModel, QModelIndex, QObject, QSettings
+from PyQt6.QtWidgets import QTreeView, QHeaderView, QWidget, QAbstractSlider, QVBoxLayout, QLabel
+from PyQt6.QtGui import QFont, QFontMetrics, QColor
 import subprocess
 import json
 import logging
@@ -35,6 +35,15 @@ from . import panel
 logger = logging.getLogger(__name__)
 
 columns = ['date', 'from', 'subject', 'tags']
+
+class HeaderView(QHeaderView):
+    def sizeHint(self) -> QSize:
+        size = super().sizeHint()
+        fm = QFontMetrics(self.font())
+        min_height = fm.height() + 8
+        if size.height() < min_height:
+            size.setHeight(min_height)
+        return size
 
 class SearchModel(QAbstractItemModel):
     """A model containing the results of a search"""
@@ -226,15 +235,17 @@ class SearchPanel(panel.Panel):
         self.q = q
         self.conf = QSettings("dodo", "dodo")
         self.tree = QTreeView()
+        header = HeaderView(Qt.Orientation.Horizontal, self.tree)
+        self.tree.setHeader(header)
         self.error_view = QLabel()
         self.tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         if settings.header_font or settings.header_font_size:
-            f = self.tree.header().font()
+            f = header.font()
             if settings.header_font:
                 f.setFamily(settings.header_font)
             if settings.header_font_size:
                 f.setPointSize(settings.header_font_size)
-            self.tree.header().setFont(f)
+            header.setFont(f)
         self.setStyleSheet(f'QTreeView::item {{ padding: {settings.search_view_padding}px }}')
         self.model = SearchModel(q)
         self.tree.setModel(self.model)

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -228,6 +228,13 @@ class SearchPanel(panel.Panel):
         self.tree = QTreeView()
         self.error_view = QLabel()
         self.tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        if settings.header_font or settings.header_font_size:
+            f = self.tree.header().font()
+            if settings.header_font:
+                f.setFamily(settings.header_font)
+            if settings.header_font_size:
+                f.setPointSize(settings.header_font_size)
+            self.tree.header().setFont(f)
         self.setStyleSheet(f'QTreeView::item {{ padding: {settings.search_view_padding}px }}')
         self.model = SearchModel(q)
         self.tree.setModel(self.model)

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -213,6 +213,30 @@ Several themes are defined in `dodo.themes`, based on the popular Nord,
 Solarized and Gruvbox color palettes.
 """
 
+tab_font = ''
+"""The font used for tab titles
+
+If empty, the system default is used.
+"""
+
+tab_font_size = 0
+"""The font size used for tab titles
+
+If 0, the system default is used.
+"""
+
+header_font = ''
+"""The font used for column headers in the search panel (date, from, subject, tags)
+
+If empty, the system default is used.
+"""
+
+header_font_size = 0
+"""The font size used for column headers in the search panel
+
+If 0, the system default is used.
+"""
+
 search_font = 'DejaVu Sans Mono'
 """The font used for search output and various other list-boxes"""
 


### PR DESCRIPTION
## Summary

Adds `tab_font`/`tab_font_size` and `header_font`/`header_font_size` settings so users can control the font used in the tab bar and the search-result column headers.

Without these settings, the tab bar height and column header height are fixed by Qt's default metrics, which can clip text when users configure a large system font or a large `search_font_size`. This change:

- Adds `dodo.settings.tab_font` / `dodo.settings.tab_font_size` and `dodo.settings.header_font` / `dodo.settings.header_font_size` (default empty/0 → use system font)
- Subclasses `QTabBar` with a custom `sizeHint` so the tab height adjusts to the configured font
- Subclasses `QHeaderView` with a custom `sizeHint` so the header height adjusts similarly

**Usage in `config.py`:**
```python
dodo.settings.tab_font = 'DejaVu Sans Mono'
dodo.settings.tab_font_size = 14
dodo.settings.header_font = 'DejaVu Sans Mono'
dodo.settings.header_font_size = 13
```

## Test plan
- [ ] Without settings, tab bar and headers look unchanged
- [ ] Set a large `dodo.settings.tab_font_size` and verify the tab bar grows to fit without clipping
- [ ] Set a large `dodo.settings.header_font_size` and verify column headers grow to fit