### PR TITLE
search: support custom tab titles for search panels

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -152,8 +152,12 @@ class Dodo(QApplication):
 
         # open init_queries and make un-closeable
         #
-        for query in settings.init_queries:
-            self.open_search(query, keep_open=True)
+        for entry in settings.init_queries:
+            if isinstance(entry, tuple):
+                query, custom_title = entry
+            else:
+                query, custom_title = entry, ''
+            self.open_search(query, keep_open=True, custom_title=custom_title)
 
     def _handle_signal_wakeup(self) -> None:
         """Called when a Unix signal wakes up the Qt event loop via the pipe"""
@@ -232,7 +236,7 @@ class Dodo(QApplication):
                 # remove the panel itself
                 self.tabs.removeTab(index)
 
-    def open_search(self, query: str, keep_open: bool=False) -> None:
+    def open_search(self, query: str, keep_open: bool=False, custom_title: str='') -> None:
         """Open a search panel with the given query
 
         If a panel with this query is already open, switch to it rather than
@@ -246,7 +250,7 @@ class Dodo(QApplication):
                 self.tabs.setCurrentIndex(i)
                 return
 
-        p = search.SearchPanel(self, query, keep_open=keep_open)
+        p = search.SearchPanel(self, query, keep_open=keep_open, custom_title=custom_title)
         self.add_panel(p)
 
     def open_thread(self, thread_id: str, query: str) -> None:

--- a/dodo/search.py
+++ b/dodo/search.py
@@ -220,10 +220,11 @@ class SearchPanel(panel.Panel):
 
     This is used as the main entry point for the GUI, i.e. a search for "tag:inbox"."""
 
-    def __init__(self, a: app.Dodo, q: str, keep_open: bool=False, parent: Optional[QWidget]=None):
+    def __init__(self, a: app.Dodo, q: str, keep_open: bool=False, custom_title: str='', parent: Optional[QWidget]=None):
         super().__init__(a, keep_open, parent)
         self.set_keymap(keymap.search_keymap)
         self.q = q
+        self.custom_title = custom_title
         self.conf = QSettings("dodo", "dodo")
         self.tree = QTreeView()
         self.error_view = QLabel()
@@ -316,7 +317,7 @@ class SearchPanel(panel.Panel):
             self.model.refresh_num_threads()
             self._dirty_title = False
         return settings.search_title_format.format(
-            query=self.q, num_threads=self.model.num_threads
+            query=self.custom_title or self.q, num_threads=self.model.num_threads
         )
 
     def next_thread(self, unread: bool=False) -> None:

--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -169,6 +169,14 @@ should be installed and configured.  Requires python-gnupg
 init_queries = [ 'tag:inbox' ]
 """List of non closable queries open at startup
 
+Each entry can be a plain query string or a ``(query, title)`` tuple to
+set a custom tab title. For example::
+
+    init_queries = [
+        'tag:inbox',
+        ('tag:flagged', 'Flagged'),
+    ]
+
 You can save query with `notmuch config set query:inbox "tag:inbox and not
 tag:trash"` and use `query:inbox` as a search term.
 """


### PR DESCRIPTION
## Summary

Allows setting custom tab titles for search panels via `dodo.settings.init_queries`.

Each entry can now be either a plain query string (existing behaviour) or a `(query, title)` tuple to override the tab label. This is useful when the notmuch query is long or cryptic but the user wants a short, readable tab name.

**Usage in `config.py`:**
```python
dodo.settings.init_queries = [
    'tag:inbox',
    ('tag:flagged', 'Flagged'),
    ('tag:inbox and not tag:lists', 'Personal'),
]
```

## Test plan
- [ ] Plain string entries in `dodo.settings.init_queries` still work as before
- [ ] `(query, title)` tuple entries display the custom title on the tab
- [ ] Refreshing a panel with a custom title preserves the title