### PR TITLE
thread: set WebEngineView background color to theme bg

### DIFF
--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -558,6 +558,7 @@ class ThreadPanel(panel.Panel):
         page = MessagePage(self.app, self.message_profile, self.message_view)
         self.message_view.setPage(page)
         self.message_view.setZoomFactor(1.2)
+        self.message_view.page().setBackgroundColor(QColor(settings.theme['bg']))
 
         self.layout_panel()
 


### PR DESCRIPTION
## Summary

Sets the WebEngineView page background color to match the current theme's `bg` color. Without this, the web engine briefly flashes white (or whatever Qt's default is) before the HTML content loads, which is jarring with dark themes.

## Test plan
- [ ] Open a thread with a dark theme — no white flash before message renders
- [ ] Open a thread with the default (light) theme — no visual change