### PR TITLE
app: call raise_() before activateWindow() so dodo comes to front on macOS

### DIFF
--- a/dodo/app.py
+++ b/dodo/app.py
@@ -172,6 +172,9 @@ class Dodo(QApplication):
 
     def raise_panel(self, p: panel.Panel) -> None:
         self.tabs.setCurrentWidget(p)
+        # raise_() brings the window to the front; activateWindow() gives it
+        # keyboard focus.  On macOS activateWindow() alone is not enough.
+        self.main_window.raise_()
         self.main_window.activateWindow()
         # self.main_window.setWindowState(self.main_window.windowState() ^ Qt.WindowActive)
 


### PR DESCRIPTION
## Summary

On macOS, when returning from an external editor (e.g. after composing a message), `activateWindow()` alone does not reliably bring the dodo window back to the foreground. Adding `raise_()` before `activateWindow()` ensures the window comes to the front and receives keyboard focus when the editor process finishes.

## Test plan
- [ ] On macOS, compose a message that opens an external editor — after saving and closing the editor, dodo's window comes to the front
- [ ] On Linux, verify no change in behaviour