### PR TITLE
Optional dark background for HTML view

### DIFF
--- a/dodo/settings.py
+++ b/dodo/settings.py
@@ -204,6 +204,14 @@ If a link is to a host in this list, it will be opened without confirmation, eve
 :func:`~dodo.settings.html_confirm_open_links` is True.
 """
 
+"""Force the HTML view to use dark mode
+
+By default the HTML view of an email will use black text on a white background, which might
+clash hard with your selected theme. This toggle forces the use of the engine's dark mode
+instead.
+"""
+html_dark_mode = False
+
 # visual
 theme = themes.nord
 """The GUI theme

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -549,6 +549,8 @@ class ThreadPanel(panel.Panel):
         self.message_profile.installUrlSchemeHandler(b'message', self.message_handler)
         self.message_profile.settings().setAttribute(
                 QWebEngineSettings.WebAttribute.JavascriptEnabled, False)
+        self.message_profile.settings().setAttribute(
+                QWebEngineSettings.WebAttribute.ForceDarkMode, settings.html_dark_mode)
 
         # The interceptor must not be garbage collected, so keep a reference
         self.url_interceptor = RemoteBlockingUrlRequestInterceptor()

--- a/dodo/thread.py
+++ b/dodo/thread.py
@@ -560,7 +560,7 @@ class ThreadPanel(panel.Panel):
         page = MessagePage(self.app, self.message_profile, self.message_view)
         self.message_view.setPage(page)
         self.message_view.setZoomFactor(1.2)
-        self.message_view.page().setBackgroundColor(QColor(settings.theme['bg']))
+        self._update_background()
 
         self.layout_panel()
 
@@ -570,6 +570,16 @@ class ThreadPanel(panel.Panel):
             if not self.thread_list.isExpanded(idx):
                 collapsed.add(self.model.message_at(idx)['id'])
         return collapsed
+
+    def _update_background(self):
+        if self.html_mode:
+            if settings.html_dark_mode:
+                color = 0
+            else:
+                color = 0xFFFFFF
+        else:
+            color = QColor(settings.theme['bg'])
+        self.message_view.page().setBackgroundColor(color)
 
     def _restore_collapsed(self, collapsed: set[str]):
         self.thread_list.expandAll()
@@ -804,6 +814,7 @@ class ThreadPanel(panel.Panel):
         """Toggle between HTML and plain text message view"""
 
         self.html_mode = not self.html_mode
+        self._update_background()
         self.refresh_content()
 
     def reply(self, to_all: bool=True) -> None:


### PR DESCRIPTION
We broke HTML view a little bit when I merge #135 as it takes on the new background color but keeps a dark text.

This fixes it in two manners:
* We can use the built-in dark mode for the HTML view
* We change the background color more selectively